### PR TITLE
自動更新機能の修正

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -52,6 +52,7 @@ $btn-color: #38aef0;
     .Group-list {
       height: calc(100vh - 100px);
       padding: 0 20px;
+      overflow: scroll;
       background-color: #2f3e51;
       &__items {
         padding: 20px 0 40px 0;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,7 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
     group = Group.find(params[:group_id])
-    last_message_id = params[:id]
+    last_message_id = params[:id].to_i
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end


### PR DESCRIPTION
# What
メッセージの自動更新機能を修正する。
現時点では、メッセージの自動更新は一度リロードを行わなければ始まらないが、リロードせずに最初から自動更新が行われるようにする。

# Why
リアルタイムでチャットするアプリであるので、リロードせずに投稿されたメッセージを自動で更新していく必要がある。